### PR TITLE
disabled touchpad button if no touchpad input is detected

### DIFF
--- a/GearVR Controller/GearVR Controller.csproj
+++ b/GearVR Controller/GearVR Controller.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows10.0.22000.0</TargetFramework>
+    <TargetFramework>net6.0-windows10.0.22621.0</TargetFramework>
     <RootNamespace>GearVR_Controller</RootNamespace>
     <UseWPF>true</UseWPF>
     <PackageIcon>logo.png</PackageIcon>
@@ -16,9 +16,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotNetProjects.WpfToolkit.Input" Version="6.0.90" />
+    <PackageReference Include="DotNetProjects.WpfToolkit.Input" Version="6.1.94" />
     <PackageReference Include="Hardcodet.NotifyIcon.Wpf" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="1.3.5" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/GearVR Controller/MainProgram.cs
+++ b/GearVR Controller/MainProgram.cs
@@ -116,6 +116,18 @@ namespace GearVR_Controller
         private void TouchpadButton()
         {
             if (Settings.Default._TouchpadButton
+                //When there is no touch input the position reads -314 and 0
+                && ((sensorData.ShiftedX == -314
+                && sensorData.ShiftedY == 0
+                && Settings.Default._TchBtn)
+                || (Settings.Default._CurrentInput == User.Default.TouchLeftButton
+                && TimePassed()
+                && !User.Default.TouchLeftButton.StartsWith("Mouse")
+                )))
+            {
+                HandleButtonUp("_TchBtn");
+            }
+            else if (Settings.Default._TouchpadButton
                     && ((Math.Pow(sensorData.AxisX - 157, 2) + Math.Pow(sensorData.AxisY - 157, 2) <= 6400
                     && Settings.Default._TchBtn)
                     || (Settings.Default._CurrentInput == User.Default.TouchMidButton
@@ -138,8 +150,8 @@ namespace GearVR_Controller
             }
             else if (Settings.Default._TouchpadButton
                 && ((sensorData.ShiftedX > 0
-                && sensorData.ShiftedY <=
-                0 && Settings.Default._TchBtn)
+                && sensorData.ShiftedY <= 0
+                && Settings.Default._TchBtn)
                 || (Settings.Default._CurrentInput == User.Default.TouchRightButton
                 && TimePassed()
                 && !User.Default.TouchRightButton.StartsWith("Mouse")


### PR DESCRIPTION
added additionnal if statement in order to detect if there is a touchpad input detected. Otherwise if the touchpad was clicked to the side or too fast a random button would be activated. The solution is a bit crude but it works.